### PR TITLE
Switch config_file to default False to fix PEP8 integration.

### DIFF
--- a/saltpylint/pep8.py
+++ b/saltpylint/pep8.py
@@ -92,7 +92,7 @@ class _PEP8BaseChecker(BaseChecker):
         '''
         if node.path not in _PROCESSED_NODES:
             stylechecker = StyleGuide(
-                parse_argv=False, config_file=True, quiet=2,
+                parse_argv=False, config_file=False, quiet=2,
                 reporter=PyLintPEP8Reporter
             )
 


### PR DESCRIPTION
The default value for the config_file kwarg passed to
StyleGuide.**init** is False; we were passing True which causes an
error when pep8 is installed, as PEP8 is expecting a filepath for the kwarg.

This isn't documented super well in PEP8; I think a better default would have
been None (or using an Optional or Maybe type, but that isn't pythonic).
