### PR TITLE
Fixes a wrong usage of a global variable.

### DIFF
--- a/saltpylint/py3modernize/__init__.py
+++ b/saltpylint/py3modernize/__init__.py
@@ -50,7 +50,7 @@ if HAS_REQUIRED_LIBS:
         FIXER_UTIL_TOUCH_IMPORT(package, name, node)
 
 else:
-    FIXES = ()
+    ALL_FIXES = ()
 
 
 def diff_texts(old, new, diff_context_lines=3):


### PR DESCRIPTION
ALL_FIXES has required in [this line](https://github.com/kstreee/salt-pylint/blob/972f21735136c11df6d5de24bff54c39f852c585/saltpylint/py3modernize/__init__.py#L122). I found a history that the line used 'FIXES'. Because the code has been changed to use ALL_FIXES by this commit 7e88657a68894deede6bdf0e2fe3f622a00d06ae, `else` case's kind of 'backup' variable should be changed.

P.S. This bug raises an exception in my development environment. 😂