### PR TITLE
Fix syntastic pylint checker and other warnings

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -259,6 +259,7 @@ spelling-store-unknown-words=no
 [BASIC]
 
 # Required attributes for module, separated by a comma
+# DEPRECATED in PyLint 2.0
 #required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
@@ -350,6 +351,7 @@ docstring-min-length=-1
 
 # List of interface methods to ignore, separated by a comma. This is used for
 # instance to not check methods defines in Zope's Interface base class.
+# DEPRECATED in PyLint 2.0
 #ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.

--- a/.pylintrc
+++ b/.pylintrc
@@ -259,7 +259,7 @@ spelling-store-unknown-words=no
 [BASIC]
 
 # Required attributes for module, separated by a comma
-required-attributes=
+#required-attributes=
 
 # List of builtins function names that should not be used, separated by a comma
 bad-functions=map,filter
@@ -350,7 +350,7 @@ docstring-min-length=-1
 
 # List of interface methods to ignore, separated by a comma. This is used for
 # instance to not check methods defines in Zope's Interface base class.
-ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+#ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
 
 # List of method names used to declare (i.e. assign) instance attributes.
 defining-attr-methods=__init__,__new__,setUp

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ SALT_PYLINT_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'requirements.tx
 
 
 def _parse_requirements_file(requirements_file):
+    '''
+    Parse requirements.txt and return list suitable for
+    passing to ``install_requires`` parameter in ``setup()``.
+    '''
     parsed_requirements = []
     with open(requirements_file) as rfh:
         for line in rfh.readlines():
@@ -36,6 +40,25 @@ def _parse_requirements_file(requirements_file):
                 continue
             parsed_requirements.append(line)
     return parsed_requirements
+
+
+def _release_version():
+    '''
+    Returns release version
+    '''
+    with io.open(os.path.join(SETUP_DIRNAME, 'saltpylint', 'version.py'), encoding='utf-8') as fh_:
+        contents = fh_.read()
+        if not isinstance(contents, str):
+            contents = contents.encode('utf-8')
+        exec(  # pylint: disable=exec-used
+            compile(
+                contents,
+                os.path.join(SETUP_DIRNAME, 'saltpylint', 'version.py'),
+                'exec'
+            )
+        )
+    # pylint: disable=undefined-variable
+    return __version__
 
 
 # Use setuptools only if the user opts-in by setting the USE_SETUPTOOLS env var.
@@ -54,21 +77,8 @@ if 'USE_SETUPTOOLS' in os.environ or 'setuptools' in sys.modules:
 if USE_SETUPTOOLS is False:
     from distutils.core import setup  # pylint: disable=import-error,no-name-in-module
 
-with io.open(os.path.join(SETUP_DIRNAME, 'saltpylint', 'version.py'), encoding='utf-8') as fh_:
-    contents = fh_.read()
-    if not isinstance(contents, str):
-        contents = contents.encode('utf-8')
-    exec(  # pylint: disable=exec-used
-        compile(
-            contents,
-            os.path.join(SETUP_DIRNAME, 'saltpylint', 'version.py'),
-            'exec'
-        )
-    )
-
-
 NAME = 'SaltPyLint'
-VERSION = __version__  # pylint: disable=undefined-variable
+VERSION = _release_version()
 DESCRIPTION = (
     'Required PyLint plugins needed in the several SaltStack projects.'
 )


### PR DESCRIPTION
Hi @s0undt3ch.

PyLint 2.0 will deprecate some options set in the `.pylintrc`, and just execution of current `pylint` (1.6) outputs complain about this exiting with non-zero status. Unfortunately, this breaks Syntastic VIM plugin (it parses PyLint version under the hood) and I was not able to check the code.
Since those two configured options (`required-attributes` and `ignore-iface-methods`) are simply matching default values, I've commented them out and everything works like a charm.

After that I could detect some missed warnings in `setup.py`. I have fixed those as well.

