### PR TITLE
Add a check for str.format in logging, fix visit_callfunc for newer pylint

### DIFF
--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -53,10 +53,7 @@ MSGS = {
     'E1322': ('Repr flag (!r) used in string: %r',
               'repr-flag-used-in-string',
               'Repr flag (!r) used in string'),
-    'E1323': ('Non-unicode-string: %r',
-              'non-unicode-string',
-              'Non-unicode string'),
-    'E1324': ('String formatting used in logging: %r',
+    'E1323': ('String formatting used in logging: %r',
               'str-format-in-logging',
               'String formatting used in logging'),
 }
@@ -171,7 +168,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                                 continue
                             if instance_type == 'logging':
                                 self.add_message(
-                                    'E1324',
+                                    'E1323',
                                     node=node,
                                     args=node.as_string(),
                                 )
@@ -195,16 +192,6 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                 self.add_message(
                     'E1320', node=node, args=node.func.expr.value
                 )
-
-    @check_messages(*(MSGS.keys()))
-    def visit_const(self, node):
-        '''
-        Flag non-unicode string literals
-        '''
-        if not six.PY2 or not isinstance(node.value, six.string_types):
-            return
-        if isinstance(node.value, str):
-            self.add_message('E1323', node=node, args=node.value)
 
 
 def register(linter):

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -176,7 +176,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                                     args=node.as_string(),
                                 )
                         ptr = parent
-                except AttributeError:
+                except (AttributeError, astroid.exceptions.NameInferenceError):
                     pass
 
             elif not hasattr(node.func.expr, 'value'):

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -122,6 +122,10 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
 
     @check_messages(*(MSGS.keys()))
     def visit_callfunc(self, node):
+        self.visit_call(node)
+
+    @check_messages(*(MSGS.keys()))
+    def visit_call(self, node):
         func = utils.safe_infer(node.func)
         if isinstance(func, astroid.BoundMethod) and func.name == 'format':
             # If there's a .format() call, run the code below


### PR DESCRIPTION
This blacklists str.format in logging, and also fixes the fact that `visit_callfunc` is now `visit_call` in newer pylint.