### PR TITLE
Fix duplicate alerts in visit_call on astroid >= 1.4

### DIFF
--- a/saltpylint/checkers.py
+++ b/saltpylint/checkers.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+'''
+    saltpylint.checkers
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Works around older astroid versions
+'''
+# Import python libs
+from __future__ import absolute_import
+
+# Import pylint libs
+import astroid
+from pylint.checkers import BaseChecker as _BaseChecker
+# Imported to avoid needing a separate import from pylint.checkers
+from pylint.checkers import utils
+
+
+class BaseChecker(_BaseChecker):
+    def __init__(self, *args, **kwargs):
+        super(BaseChecker, self).__init__(*args, **kwargs)
+        if hasattr(self, 'visit_call') and not hasattr(astroid, 'Call'):
+            setattr(self, 'visit_callfunc', self.visit_call)
+

--- a/saltpylint/fileperms.py
+++ b/saltpylint/fileperms.py
@@ -21,7 +21,7 @@ import stat
 
 # Import PyLint libs
 from pylint.interfaces import IRawChecker
-from pylint.checkers import BaseChecker
+from saltpylint.checkers import BaseChecker
 
 
 class FilePermsChecker(BaseChecker):

--- a/saltpylint/minpyver.py
+++ b/saltpylint/minpyver.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 # Import PyLint libs
 from pylint.interfaces import IRawChecker
-from pylint.checkers import BaseChecker
+from saltpylint.checkers import BaseChecker
 
 # Import 3rd-party libs
 try:

--- a/saltpylint/pep263.py
+++ b/saltpylint/pep263.py
@@ -17,7 +17,7 @@ import itertools
 
 # Import PyLint libs
 from pylint.interfaces import IRawChecker
-from pylint.checkers import BaseChecker
+from saltpylint.checkers import BaseChecker
 
 # Import 3rd-party libs
 import six

--- a/saltpylint/pep8.py
+++ b/saltpylint/pep8.py
@@ -26,7 +26,7 @@ import six
 
 # Import PyLint libs
 from pylint.interfaces import IRawChecker
-from pylint.checkers import BaseChecker
+from saltpylint.checkers import BaseChecker
 from pylint.__pkginfo__ import numversion as pylint_version_info
 
 # Import PEP8 libs

--- a/saltpylint/py3modernize/__init__.py
+++ b/saltpylint/py3modernize/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
 
 # Import PyLint libs
 from pylint.interfaces import IRawChecker
-from pylint.checkers import BaseChecker
+from saltpylint.checkers import BaseChecker
 
 if HAS_REQUIRED_LIBS:
     FIXES = lib2to3_fix_names

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -31,7 +31,7 @@ except ImportError:  # < pylint 1.0
 
 from astroid.exceptions import InferenceError
 try:
-    from  astroid.exceptions import NameInferenceError
+    from astroid.exceptions import NameInferenceError
 except ImportError:
     class NameInferenceError(Exception):
         pass

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -21,9 +21,7 @@ try:
     import astroid
 except ImportError:  # pylint < 1.0
     from logilab import astng as astroid  # pylint: disable=no-name-in-module
-from pylint.checkers import utils
-from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages, parse_format_string
+from saltpylint.checkers import BaseChecker, utils
 
 try:
     # >= pylint 1.0
@@ -92,7 +90,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                  ),
                )
 
-    @check_messages(*(MSGS.keys()))
+    @utils.check_messages(*(MSGS.keys()))
     def visit_binop(self, node):
         if not self.config.enforce_string_formatting_over_substitution:
             return
@@ -105,7 +103,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
             return
 
         try:
-            required_keys, required_num_args = parse_format_string(node.left.value)
+            required_keys, required_num_args = utils.parse_format_string(node.left.value)
         except (utils.UnsupportedFormatCharacter, utils.IncompleteFormatString):
             # This is handled elsewere
             return
@@ -124,11 +122,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                 'E1322', node=node.left, args=node.left.value
             )
 
-    @check_messages(*(MSGS.keys()))
-    def visit_callfunc(self, node):
-        self.visit_call(node)
-
-    @check_messages(*(MSGS.keys()))
+    @utils.check_messages(*(MSGS.keys()))
     def visit_call(self, node):
         func = utils.safe_infer(node.func)
         if isinstance(func, astroid.BoundMethod) and func.name == 'format':

--- a/saltpylint/thirdparty.py
+++ b/saltpylint/thirdparty.py
@@ -22,8 +22,7 @@ import astroid
 import astroid.exceptions
 from astroid.modutils import is_relative, is_standard_module
 from pylint.interfaces import IAstroidChecker
-from pylint.checkers import BaseChecker
-from pylint.checkers.utils import check_messages
+from saltpylint.checkers import BaseChecker, utils
 
 MSGS = {
     'W8410': ('3rd-party module import is not gated in a try/except: %r',
@@ -81,38 +80,38 @@ class ThirdPartyImportsChecker(BaseChecker):
         self.allowed_3rd_party_modules = set(self.config.allowed_3rd_party_modules)  # pylint: disable=no-member
 
     # pylint: disable=unused-argument
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def visit_if(self, node):
         self._inside_if = True
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def leave_if(self, node):
         self._inside_if = True
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def visit_tryexcept(self, node):
         self._inside_try_except = True
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def leave_tryexcept(self, node):
         self._inside_try_except = False
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def visit_functiondef(self, node):
         self._inside_funcdef = True
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def leave_functiondef(self, node):
         self._inside_funcdef = True
     # pylint: enable=unused-argument
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def visit_import(self, node):
         names = [name for name, _ in node.names]
         for name in names:
             self._check_third_party_import(node, name)
 
-    @check_messages('3rd-party-imports')
+    @utils.check_messages('3rd-party-imports')
     def visit_importfrom(self, node):
         self._check_third_party_import(node, node.modname)
 


### PR DESCRIPTION
Version 1.4 of astroid added the `astroid.Call` attribute. Earlier astroid releases will not have this attribute, and will not have a `visit_call` method, while astroid releases 1.4 <= n < 2.0 will call both `visit_callfunc` and `visit_call` if present, resulting in duplicate alerts. This modified version of the BaseChecker will add a `visit_callfunc` only when `astroid.Call` is not present. This allows older astroid releases to be supported while also avoiding duplicate alerts on astroid >= 1.4.