### PR TITLE
warning: The following code, E8741, was not handled by the PEP8 plugin

### DIFF
--- a/saltpylint/pep8.py
+++ b/saltpylint/pep8.py
@@ -330,6 +330,8 @@ class PEP8Statement(_PEP8BaseChecker):
                   'do-not-compare-types-use-isinstance'),
         'E8731': ('PEP8 %s: %s',
                   'do-not-assign-a-lambda-expression-use-a-def'),
+        'E8741': ('PEP8 %s: %s',
+                  'bad-variable-identifier-name'),
     }
 
 


### PR DESCRIPTION
PEP8 E741 recommends strongly against variables named 'l' because some fonts make them difficult to distinguish from other characters.

salt-pylint converts these to E8741, which need to be handled locally.