### PR TITLE
Newer pylint returns four values from utils.parse_format_string()

### DIFF
--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -106,7 +106,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
             return
 
         try:
-            required_keys, required_num_args = utils.parse_format_string(node.left.value)
+            required_keys, required_num_args = utils.parse_format_string(node.left.value)[:2]
         except (utils.UnsupportedFormatCharacter, utils.IncompleteFormatString):
             # This is handled elsewere
             return


### PR DESCRIPTION
This uses slicing to work with both older and newer pylint