### PR TITLE
Fix a duplicate warning in str-format-in-logging

### DIFF
--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -178,6 +178,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                                     node=node,
                                     args=node.as_string(),
                                 )
+                                break
                         ptr = parent
                 except (AttributeError, InferenceError, NameInferenceError):
                     pass


### PR DESCRIPTION
This check works by walking up the parents of a function call, but on some versions of Python the logging functions (warning, error, debug, etc.) have an instance type of `logging`. This means that when we continue to walk back up to the logger object itself, we warn a second time. This commit fixes this duplicate warning by breaking out of the for loop once we've warned.