### PR TITLE
initial import of __virtual__ log check

### DIFF
--- a/saltpylint/virt.py
+++ b/saltpylint/virt.py
@@ -15,7 +15,7 @@ class Virt_Checker(BaseChecker):
     VIRT_LOG = 'log-in-virtual'
 
     msgs = {
-        'E1401': ('Log statment detected inside __virtual__ function. Remove it.',
+        'E1401': ('Log statement detected inside __virtual__ function. Remove it.',
                   VIRT_LOG,
                   'Loader processes __virtual__ so logging not in scope'),
     }

--- a/saltpylint/virt.py
+++ b/saltpylint/virt.py
@@ -1,0 +1,63 @@
+from __future__ import absolute_import
+import astroid
+
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+
+class Virt_Checker(BaseChecker):
+    '''
+    checks for compliance inside __virtual__
+    '''
+    __implements__ = IAstroidChecker
+
+    name = 'virt-checker'
+
+    VIRT_LOG = 'log-in-virtual'
+
+    msgs = {
+        'E1401': ('Log statment detected inside __virtual__ function. Remove it.',
+                  VIRT_LOG,
+                  'Loader processes __virtual__ so logging not in scope'),
+    }
+    options = ()
+
+    priority = -1
+
+    def visit_functiondef(self, node):
+        '''
+        Verifies no logger statements inside __virtual__
+        '''
+        if (not isinstance(node, astroid.FunctionDef) or
+            node.is_method()
+            or node.type != 'function'
+            or not node.body
+           ):
+            # only process functions
+            return
+
+        try:
+            if not node.name == '__virtual__':
+                # only need to process the __virtual__ function
+                return
+        except AttributeError:
+            return
+
+        # walk contents of __virtual__ function
+        for child in node.get_children():
+            for functions in child.get_children():
+                if isinstance(functions, astroid.Call):
+                    if isinstance(functions.func, astroid.Attribute):
+                        try:
+                            if 'log' == functions.func.expr.name:
+                                self.add_message(
+                                    self.VIRT_LOG, node=functions
+                                )
+                        except AttributeError:
+                            # Not a log function
+                            return
+
+def register(linter):
+    '''
+    required method to auto register this checker
+    '''
+    linter.register_checker(Virt_Checker(linter))


### PR DESCRIPTION
Attempts to address issues:
saltstack/salt#49935
#2 
saltstack/salt-testing#34

For test:
```
# -*- coding: utf-8 -*-
'''
some broken lint test
'''

# Import Python libs
from __future__ import absolute_import, unicode_literals, print_function
import logging

log = logging.getLogger(__name__)

__virtualname__ = 'broken'


def __virtual__():
    '''
    Check dependencies - may be useful in future
    '''

    log.error('not allowed')

    log.debug("some text")
    return __virtualname__

```

Results in:
```
pylint salt/modules/ --load-plugins=saltpylint.custom --rcfile=.testing.pylintrc  --disable=all --enable=log-in-virtual
  RuntimeWarning
************* Module salt.modules.broken
salt/modules/broken.py:20: [E1401(log-in-virtual), __virtual__] Log statement detected inside __virtual__ function. Remove it.
salt/modules/broken.py:22: [E1401(log-in-virtual), __virtual__] Log statement detected inside __virtual__ function. Remove it.
```

@gtmanfred @s0undt3ch 