### PR TITLE
upgrade salt-pylint to work with pylint 3.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# salt-pylint

--- a/saltpylint/blacklist.py
+++ b/saltpylint/blacklist.py
@@ -19,7 +19,6 @@ import fnmatch
 # Import pylint libs
 import astroid
 from saltpylint.checkers import BaseChecker, utils
-from pylint.interfaces import IAstroidChecker
 
 BLACKLISTED_IMPORTS_MSGS = {
     'E9402': ('Uses of a blacklisted module %r: %s',
@@ -46,8 +45,6 @@ BLACKLISTED_IMPORTS_MSGS = {
 
 class BlacklistedImportsChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'blacklisted-imports'
     msgs = BLACKLISTED_IMPORTS_MSGS
     priority = -2
@@ -62,7 +59,6 @@ class BlacklistedImportsChecker(BaseChecker):
                                     'unittest',
                                     'unittest2')
 
-    @utils.check_messages('blacklisted-imports')
     def visit_import(self, node):
         '''triggered when an import statement is seen'''
         module_filename = node.root().file
@@ -75,7 +71,6 @@ class BlacklistedImportsChecker(BaseChecker):
         for name in names:
             self._check_blacklisted_module(node, name)
 
-    @utils.check_messages('blacklisted-imports')
     def visit_importfrom(self, node):
         '''triggered when a from statement is seen'''
         module_filename = node.root().file
@@ -238,8 +233,6 @@ BLACKLISTED_LOADER_USAGE_MSGS = {
 
 class BlacklistedLoaderModulesUsageChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'blacklisted-unmocked-patching'
     msgs = BLACKLISTED_LOADER_USAGE_MSGS
     priority = -2
@@ -259,21 +252,18 @@ class BlacklistedLoaderModulesUsageChecker(BaseChecker):
         self.process_module = False
         self.imported_salt_modules = {}
 
-    @utils.check_messages('blacklisted-unmocked-patching')
     def visit_module(self, node):
         module_filename = node.root().file
         if not fnmatch.fnmatch(os.path.basename(module_filename), 'test_*.py*'):
             return
         self.process_module = True
 
-    @utils.check_messages('blacklisted-unmocked-patching')
     def leave_module(self, node):
         if self.process_module:
             # Reset
             self.process_module = False
             self.imported_salt_modules = {}
 
-    @utils.check_messages('blacklisted-unmocked-patching')
     def visit_import(self, node):
         '''triggered when an import statement is seen'''
         if self.process_module:
@@ -287,7 +277,6 @@ class BlacklistedLoaderModulesUsageChecker(BaseChecker):
                 if module not in self.imported_salt_modules:
                     self.imported_salt_modules[module] = module
 
-    @utils.check_messages('blacklisted-unmocked-patching')
     def visit_importfrom(self, node):
         '''triggered when a from statement is seen'''
         if self.process_module:
@@ -301,7 +290,6 @@ class BlacklistedLoaderModulesUsageChecker(BaseChecker):
                 if module not in self.imported_salt_modules:
                     self.imported_salt_modules[module] = module
 
-    @utils.check_messages('blacklisted-loader-usage')
     def visit_assign(self, node, *args):
         if not self.process_module:
             return
@@ -363,8 +351,6 @@ RESOURCE_LEAKAGE_MSGS = {
 
 class ResourceLeakageChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'resource-leakage'
     msgs = RESOURCE_LEAKAGE_MSGS
     priority = -2
@@ -413,8 +399,6 @@ MOVED_TEST_CASE_CLASSES_MSGS = {
 
 class MovedTestCaseClassChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'moved-test-case-class'
     msgs = MOVED_TEST_CASE_CLASSES_MSGS
     priority = -2
@@ -425,20 +409,17 @@ class MovedTestCaseClassChecker(BaseChecker):
     def close(self):
         self.process_module = False
 
-    @utils.check_messages('moved-test-case-class')
     def visit_module(self, node):
         module_filename = node.root().file
         if not fnmatch.fnmatch(os.path.basename(module_filename), 'test_*.py*'):
             return
         self.process_module = True
 
-    @utils.check_messages('moved-test-case-class')
     def leave_module(self, node):
         if self.process_module:
             # Reset
             self.process_module = False
 
-    @utils.check_messages('moved-test-case-class')
     def visit_importfrom(self, node):
         '''triggered when a from statement is seen'''
         if self.process_module:
@@ -451,7 +432,6 @@ class MovedTestCaseClassChecker(BaseChecker):
                     continue
                 self._check_moved_imports(node, module)
 
-    @utils.check_messages('moved-test-case-class')
     def visit_classdef(self, node):
         for base in node.bases:
             if not hasattr(base, 'attrname'):
@@ -488,8 +468,6 @@ BLACKLISTED_FUNCTIONS_MSGS = {
 
 class BlacklistedFunctionsChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'blacklisted-functions'
     msgs = BLACKLISTED_FUNCTIONS_MSGS
     priority = -2
@@ -505,16 +483,6 @@ class BlacklistedFunctionsChecker(BaseChecker):
 
     def open(self):
         self.blacklisted_functions = {}
-        blacklist = [
-            x.strip() for x in self.config.blacklisted_functions.split(',')]
-        for item in [x.strip() for x in
-                     self.config.blacklisted_functions.split(',')]:
-            try:
-                key, val = [x.strip() for x in item.split('=')]
-            except ValueError:
-                pass
-            else:
-                self.blacklisted_functions[key] = val
 
     def _get_full_name(self, node):
         try:
@@ -542,7 +510,6 @@ class BlacklistedFunctionsChecker(BaseChecker):
         # full name for the function.
         return '.'.join(ret[::-1])
 
-    @utils.check_messages('blacklisted-functions')
     def visit_call(self, node):
         if self.blacklisted_functions:
             full_name = self._get_full_name(node)

--- a/saltpylint/blacklist.py
+++ b/saltpylint/blacklist.py
@@ -483,6 +483,15 @@ class BlacklistedFunctionsChecker(BaseChecker):
 
     def open(self):
         self.blacklisted_functions = {}
+        blacklist = [
+            x.strip() for x in self.linter.config.blacklisted_functions.split(',')]
+        for item in blacklist:
+            try:
+                key, val = [x.strip() for x in item.split('=')]
+            except ValueError:
+                pass
+            else:
+                self.blacklisted_functions[key] = val
 
     def _get_full_name(self, node):
         try:

--- a/saltpylint/fileperms.py
+++ b/saltpylint/fileperms.py
@@ -20,7 +20,6 @@ import glob
 import stat
 
 # Import PyLint libs
-from pylint.interfaces import IRawChecker
 from saltpylint.checkers import BaseChecker
 
 
@@ -28,8 +27,6 @@ class FilePermsChecker(BaseChecker):
     '''
     Check for files with undesirable permissions
     '''
-
-    __implements__ = IRawChecker
 
     name = 'fileperms'
     msgs = {'E0599': ('Module file has the wrong file permissions(expected %s): %s',

--- a/saltpylint/minpyver.py
+++ b/saltpylint/minpyver.py
@@ -18,7 +18,6 @@ from __future__ import absolute_import
 import sys
 
 # Import PyLint libs
-from pylint.interfaces import IRawChecker
 from saltpylint.checkers import BaseChecker
 
 # Import 3rd-party libs
@@ -39,8 +38,6 @@ class MininumPythonVersionChecker(BaseChecker):
     '''
     Check the minimal required python version
     '''
-
-    __implements__ = IRawChecker
 
     name = 'mininum-python-version'
     msgs = {'E0598': ('Incompatible Python %s code found: %s',

--- a/saltpylint/pep263.py
+++ b/saltpylint/pep263.py
@@ -16,7 +16,6 @@ import re
 import itertools
 
 # Import PyLint libs
-from pylint.interfaces import IRawChecker
 from saltpylint.checkers import BaseChecker
 
 # Import 3rd-party libs
@@ -27,8 +26,6 @@ class FileEncodingChecker(BaseChecker):
     '''
     Check for PEP263 compliant file encoding in file.
     '''
-
-    __implements__ = IRawChecker
 
     name = 'pep263'
     msgs = {'W9901': ('PEP263: Multiple file encodings',

--- a/saltpylint/pep8.py
+++ b/saltpylint/pep8.py
@@ -25,7 +25,6 @@ import warnings
 import six
 
 # Import PyLint libs
-from pylint.interfaces import IRawChecker
 from pylint.__pkginfo__ import numversion as pylint_version_info
 from saltpylint.checkers import BaseChecker
 
@@ -63,8 +62,6 @@ if HAS_PEP8 is True:
 
 
 class _PEP8BaseChecker(BaseChecker):
-
-    __implements__ = IRawChecker
 
     name = 'pep8'
 

--- a/saltpylint/py3modernize/__init__.py
+++ b/saltpylint/py3modernize/__init__.py
@@ -20,7 +20,6 @@ except ImportError:
     )
 
 # Import PyLint libs
-from pylint.interfaces import IRawChecker
 from saltpylint.checkers import BaseChecker
 
 if HAS_REQUIRED_LIBS:
@@ -94,8 +93,6 @@ class Py3Modernize(BaseChecker):
     '''
     Check for PEP263 compliant file encoding in file.
     '''
-
-    __implements__ = IRawChecker
 
     name = 'modernize'
     msgs = {'W1698': ('Unable to run modernize. Parse Error: %s',

--- a/saltpylint/py3modernize/__init__.py
+++ b/saltpylint/py3modernize/__init__.py
@@ -241,4 +241,7 @@ def register(linter):
     required method to auto register this checker
     '''
     if HAS_REQUIRED_LIBS:
-        linter.register_checker(Py3Modernize(linter))
+        try : 
+            linter.register_checker(Py3Modernize(linter))
+        except Exception as err:
+            logging.getLogger(__name__).warn(f"Error while register Py3Modernize linter, unexpected {err=}, {type(err)=}")            

--- a/saltpylint/py3modernize/__init__.py
+++ b/saltpylint/py3modernize/__init__.py
@@ -244,4 +244,4 @@ def register(linter):
         try : 
             linter.register_checker(Py3Modernize(linter))
         except Exception as err:
-            logging.getLogger(__name__).warn(f"Error while register Py3Modernize linter, unexpected {err=}, {type(err)=}")            
+            logging.getLogger(__name__).warning(f"Error while register Py3Modernize linter, unexpected {err=}, {type(err)=}")            

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -25,13 +25,6 @@ except ImportError:  # pylint < 1.0
 from saltpylint.checkers import BaseChecker, utils
 from pylint.checkers import BaseTokenChecker
 
-try:
-    # >= pylint 1.0
-    from pylint.interfaces import IAstroidChecker
-except ImportError:  # < pylint 1.0
-    from pylint.interfaces import IASTNGChecker as IAstroidChecker  # pylint: disable=no-name-in-module
-
-from pylint.interfaces import ITokenChecker, IRawChecker
 from astroid.exceptions import InferenceError
 try:
     from astroid.exceptions import NameInferenceError
@@ -71,8 +64,6 @@ BAD_FORMATTING_SLOT = re.compile(r'(\{![\w]{1}\}|\{\})')
 
 class StringCurlyBracesFormatIndexChecker(BaseChecker):
 
-    __implements__ = IAstroidChecker
-
     name = 'string'
     msgs = STRING_FORMAT_MSGS
     priority = -1
@@ -93,11 +84,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                  ),
                )
 
-    @utils.check_messages(*(STRING_FORMAT_MSGS.keys()))
     def visit_binop(self, node):
-        if not self.config.enforce_string_formatting_over_substitution:
-            return
-
         if node.op != '%':
             return
 
@@ -112,10 +99,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
             return
 
         if required_keys or required_num_args:
-            if self.config.string_substitutions_usage_is_an_error:
-                msgid = 'E1321'
-            else:
-                msgid = 'W1321'
+            msgid = 'W1321'
             self.add_message(
                 msgid, node=node.left, args=node.left.value
             )
@@ -125,7 +109,6 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                 'E1322', node=node.left, args=node.left.value
             )
 
-    @utils.check_messages(*(STRING_FORMAT_MSGS.keys()))
     def visit_call(self, node):
         func = utils.safe_infer(node.func)
         if isinstance(func, astroid.BoundMethod) and func.name == 'format':
@@ -151,8 +134,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                         )
 
                     if BAD_FORMATTING_SLOT.findall(inferred.value):
-                        if self.config.un_indexed_curly_braces_always_error or \
-                                sys.version_info[:2] < (2, 7):
+                        if sys.version_info[:2] < (2, 7):
                             self.add_message(
                                 'E1320', node=inferred, args=inferred.value
                             )
@@ -212,7 +194,6 @@ class StringLiteralChecker(BaseTokenChecker):
     '''
     Check string literals
     '''
-    __implements__ = (ITokenChecker, IRawChecker)
     name = 'string_literal'
     msgs = STRING_LITERALS_MSGS
 

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -137,7 +137,7 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
                         )
 
                     if BAD_FORMATTING_SLOT.findall(inferred.value):
-                        if sys.version_info[:2] < (2, 7):
+                        if self.linter.config.un_indexed_curly_braces_always_error:
                             self.add_message(
                                 'E1320', node=inferred, args=inferred.value
                             )

--- a/saltpylint/strings.py
+++ b/saltpylint/strings.py
@@ -99,7 +99,10 @@ class StringCurlyBracesFormatIndexChecker(BaseChecker):
             return
 
         if required_keys or required_num_args:
-            msgid = 'W1321'
+            if self.linter.config.string_substitutions_usage_is_an_error:
+                msgid = 'E1321'
+            else:
+                msgid = 'W1321'
             self.add_message(
                 msgid, node=node.left, args=node.left.value
             )

--- a/saltpylint/thirdparty.py
+++ b/saltpylint/thirdparty.py
@@ -22,7 +22,6 @@ import astroid
 import astroid.exceptions
 import pkgutil
 from astroid.modutils import is_relative, is_standard_module
-from pylint.interfaces import IAstroidChecker
 from saltpylint.checkers import BaseChecker, utils
 
 MSGS = {
@@ -48,8 +47,6 @@ def get_import_package(modname):
 
 
 class ThirdPartyImportsChecker(BaseChecker):
-
-    __implements__ = IAstroidChecker
 
     name = '3rd-party-imports'
     msgs = MSGS
@@ -83,46 +80,37 @@ class ThirdPartyImportsChecker(BaseChecker):
         self._inside_try_except = False
         self._inside_funcdef = False
         self._inside_if = False
-        self.cwd = self.allowed_3rd_party_modules = None
+        self.cwd = self.allowed_3rd_party_modules = []
 
     def open(self):
         super(ThirdPartyImportsChecker, self).open()
         self.cwd = os.getcwd()
-        self.allowed_3rd_party_modules = set(self.config.allowed_3rd_party_modules)  # pylint: disable=no-member
 
     # pylint: disable=unused-argument
-    @utils.check_messages('3rd-party-imports')
     def visit_if(self, node):
         self._inside_if = True
 
-    @utils.check_messages('3rd-party-imports')
     def leave_if(self, node):
         self._inside_if = True
 
-    @utils.check_messages('3rd-party-imports')
     def visit_tryexcept(self, node):
         self._inside_try_except = True
 
-    @utils.check_messages('3rd-party-imports')
     def leave_tryexcept(self, node):
         self._inside_try_except = False
 
-    @utils.check_messages('3rd-party-imports')
     def visit_functiondef(self, node):
         self._inside_funcdef = True
 
-    @utils.check_messages('3rd-party-imports')
     def leave_functiondef(self, node):
         self._inside_funcdef = False
     # pylint: enable=unused-argument
 
-    @utils.check_messages('3rd-party-imports')
     def visit_import(self, node):
         names = [name for name, _ in node.names]
         for name in names:
             self._check_third_party_import(node, name)
 
-    @utils.check_messages('3rd-party-imports')
     def visit_importfrom(self, node):
         self._check_third_party_import(node, node.modname)
 

--- a/saltpylint/thirdparty.py
+++ b/saltpylint/thirdparty.py
@@ -86,6 +86,7 @@ class ThirdPartyImportsChecker(BaseChecker):
     def open(self):
         super(ThirdPartyImportsChecker, self).open()
         self.cwd = os.getcwd()
+        self.allowed_3rd_party_modules = set(self.linter.config.allowed_3rd_party_modules)  # pylint: disable=no-member
 
     # pylint: disable=unused-argument
     def visit_if(self, node):

--- a/saltpylint/thirdparty.py
+++ b/saltpylint/thirdparty.py
@@ -80,7 +80,8 @@ class ThirdPartyImportsChecker(BaseChecker):
         self._inside_try_except = False
         self._inside_funcdef = False
         self._inside_if = False
-        self.cwd = self.allowed_3rd_party_modules = []
+        self.cwd = None
+        self.allowed_3rd_party_modules = []
 
     def open(self):
         super(ThirdPartyImportsChecker, self).open()


### PR DESCRIPTION
Current saltpylint works with pylint==2.13.9. It does not work with
newer versions of pylint such as 2.17 ... 3.0.3. Pylint 3.0.3 includes
many code changes, such as remove exposed checker interfaces, remove
some https://github.com/utils fucitons, remove checker member functions (config)  .. The
submitted pr removes those disappeared functions. Review is required to
make sure it does not remove necessary checks as a result.

This commit will fix issues
- https://github.com/saltstack/salt-pylint/issues/48
- https://github.com/saltstack/salt-pylint/issues/47